### PR TITLE
Add research page to display spreadsheet

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,1 +1,14 @@
-
+document.addEventListener('DOMContentLoaded', () => {
+  const table = document.getElementById('research-table');
+  if (table) {
+    fetch('assets/research%20papers.xlsx')
+      .then(response => response.arrayBuffer())
+      .then(data => {
+        const workbook = XLSX.read(data, { type: 'array' });
+        const sheetName = workbook.SheetNames[0];
+        const html = XLSX.utils.sheet_to_html(workbook.Sheets[sheetName]);
+        table.innerHTML = html;
+      })
+      .catch(error => console.error('Error loading research papers:', error));
+  }
+});

--- a/research.html
+++ b/research.html
@@ -1,0 +1,272 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta
+      name="title"
+      content="Dr N Junior Sundresh"
+    />
+    <meta
+      name="description"
+      content="Official site of Dr N Junior Sundresh."
+    />
+    <meta
+      name="keywords"
+      content="drjuniorsundresh"
+    />
+    <meta name="robots" content="index, follow" />
+    <meta name="language" content="English" />
+    <meta name="revisit-after" content="3 days" />
+    <meta name="author" content="VIK" />
+
+    <title>Research - Dr N Junior Sundresh</title>
+
+    <!-- Additional CSS Files -->
+    <link
+      rel="stylesheet"
+      href="assets/vendor/bootstrap-icons/bootstrap-icons.css"
+    />
+    <link rel="stylesheet" href="assets/vendor/aos/aos.css" />
+    <link rel="stylesheet" href="https://unpkg.com/aos@2.3.1/dist/aos.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@splidejs/splide@3.6.12/dist/css/splide.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://use.fontawesome.com/releases/v5.8.2/css/all.css"
+      integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay"
+      crossorigin="anonymous"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+
+    <!-- Google Web Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Barlow:wght@600;700&family=Ubuntu:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+
+    <!-- Icon Font Stylesheet -->
+    <link
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.0/css/all.min.css"
+      rel="stylesheet"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.1/font/bootstrap-icons.css"
+      rel="stylesheet"
+    />
+
+    <!-- cgmcico -->
+    <link rel="icon" type="image/x-icon" href="assets/images/cgmcico.jpg" />
+  </head>
+
+  <body>
+    <!-- ======= Start Header ======= -->
+    <header class="site-header">
+      <div class="container">
+        <div class="row">
+          <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
+            <p class="d-flex mb-0">
+              <i class="bi-envelope me-2"></i>
+              <a href="mailto:juniorsundresh@gmail.com"> juniorsundresh@gmail.com </a>
+            </p>
+          </div>
+          <div class="col-lg-3 col-12 ms-auto d-lg-block d-none">
+            <p class="d-flex mb-0">
+              <i class="bi-geo-alt me-2"></i>
+              ANNAMALAI NAGAR, CHIDAMBARAM - 608002
+            </p>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <div class="text-center">
+      <a href="index.html">
+        <img
+          class="img-fluid"
+          src="assets/images/drjs-banner.png"
+          alt="CGMC banner"
+          width="100%"
+        />
+      </a>
+    </div>
+
+    <nav class="navbar navbar-light navbar-expand-lg bg-white shadow-lg">
+      <div class="container">
+        <button
+          class="navbar-toggler"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#main_nav"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+        >
+          <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <div class="collapse navbar-collapse" id="main_nav">
+          <ul class="navbar-nav">
+            <li class="nav-item">
+              <a class="nav-link click-scroll nav-link-ltr" href="index.html">Home</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link click-scroll nav-link-ltr" href="about.html">About</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link click-scroll nav-link-ltr" href="research.html">Research</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link click-scroll nav-link-ltr" href="projects.html">Projects</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link click-scroll nav-link-ltr" href="publications.html">Publications</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link click-scroll nav-link-ltr" href="contact.html">Contact</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+    <div class="container py-5">
+      <h1>Research Papers</h1>
+      <table id="research-table"></table>
+    </div>
+
+    <!-- ======= Start Footer Section ======= -->
+    <div
+      class="container-fluid text-light footer pt-5 wow fadeIn"
+      data-wow-delay="0.1s"
+      style="background-color: var(--primary-color)"
+    >
+      <div class="container py-5">
+        <div class="row g-5">
+          <div class="col-md-6 col-lg-3">
+            <img
+              src="assets/images/drjsico.png"
+              alt="CGMC icon"
+              class="img-fluid footer-logo"
+            />
+            <h5
+              class="text-white mb-4"
+              style="word-spacing: 5px; letter-spacing: 1px"
+            >
+              Dr N Junior Sundresh
+            </h5>
+            <a
+              ><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR,
+              CHIDAMBARAM - 608002</a
+            >
+            <br />
+            <a><i class="fa fa-envelope me-3"></i>juniorsundresh@gmail.com</a> <br />
+            <br />
+          </div>
+          <div class="col-md-6 col-lg-3">
+            <a href="index.html">
+              <h5 class="text-white mb-4">Home</h5>
+            </a>
+            <a class="btn btn-link" href="index.html">About Dr JS</a>
+            <a class="btn btn-link" href="page_Under_Construction.html"
+              >Downloads</a
+            >
+          </div>
+          <div class="col-md-6 col-lg-3"></div>
+          <div class="col-md-6 col-lg-3">
+            <h5 class="text-white mb-4">Get in Touch</h5>
+            <a href="contact.html">
+              <div class="button_container-f">
+                <button class="btn-f">
+                  <span
+                    >Contact Us &nbsp; <i class="bi bi-send-check-fill"></i
+                  ></span>
+                </button>
+              </div>
+            </a>
+            <a href="https://forms.gle/DNmtYv1Z3Ckwwxpx6">
+              <div class="button_container-f2" style="margin-top: 80px">
+                <button class="btn-f2">
+                  <span
+                    >Feedback &nbsp;<i class="bi bi-chat-left-quote-fill"></i
+                  ></span>
+                </button>
+              </div>
+            </a>
+          </div>
+        </div>
+      </div>
+      <div class="container">
+        <div class="copyright">
+          <div class="row">
+            <div class="col-md-6 text-center text-md-start mb-3 mb-md-0">
+              &copy;
+              <a class="border-bottom" href="#"
+                >Copyright 2025 Dr N Junior Sundresh </a
+              >, All Right Reserved.
+            </div>
+            <div class="col-md-6 text-center text-md-end">
+              <div class="footer-menu">
+                Designed & Developed By :
+                <a class="border-bottom" href="https://cgtud"> <b>JS </b></a>
+                ,
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- ======= end Footer Section ======= -->
+
+    <!-- ======= JavaScript links  ======== -->
+    <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+    <script src="assets/js/main.js"></script>
+    <script src="assets/vendor/bootstrap/js/bootstrap.min.js"></script>
+    <script src="assets/vendor/aos/aos.js"></script>
+    <script src="assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js"
+      integrity="sha384-oBqDVmMz9ATKxIep9tiCxS/Z9fNfEXiDAYTujMAeBAsjFuCZSmKbSSUnQlmh/jp3"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.min.js"
+      integrity="sha384-mQ93GR66B00ZXjt0YO5KlohRA5SY2XofN4zfuZxLkoj1gXtW8ANNCe9d5Y3eG5eD"
+      crossorigin="anonymous"
+    ></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script
+      src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+      integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+      crossorigin="anonymous"
+    ></script>
+
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+      integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+      crossorigin="anonymous"
+    ></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add research.html with header/footer and placeholder table for research papers
- load SheetJS from CDN to parse local research papers spreadsheet and render as HTML
- implement script in main.js to fetch spreadsheet and inject generated HTML table

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ae003834832aa8edc4ee3684dba4