### PR TITLE
Render teaching experience on About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -146,6 +146,9 @@
       <p>
         Through my work, I aim to bridge clinical expertise with academic scholarship and healthcare administration, contributing to the holistic improvement of medical education and public health services in India.
       </p>
+
+      <h2>Teaching Experience</h2>
+      <table id="teaching-exp-table"></table>
     </div>
     <!-- ======= end About Content ======= -->
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   loadSheet('research-table', 'assets/research%20papers.xlsx');
   loadSheet('projects-table', 'assets/projects.xlsx');
+  loadSheet('teaching-exp-table', 'assets/teaching_exp.xlsx');
 });
 
 function loadSheet(elementId, url) {


### PR DESCRIPTION
## Summary
- display teaching experience spreadsheet on About page
- load Excel data via `loadSheet` helper

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68c7bb6b1e3c832a89306f8667c3a7ea