### PR TITLE
Use div containers for sheet-rendered tables

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -5,14 +5,14 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 function loadSheet(elementId, url) {
-  const table = document.getElementById(elementId);
-  if (!table) return;
+  const container = document.getElementById(elementId);
+  if (!container) return;
   fetch(url)
     .then(res => res.arrayBuffer())
     .then(data => {
       const wb = XLSX.read(data, { type: 'array' });
       const sheet = wb.SheetNames[0];
-      table.innerHTML = XLSX.utils.sheet_to_html(wb.Sheets[sheet]);
+      container.innerHTML = XLSX.utils.sheet_to_html(wb.Sheets[sheet]);
     })
     .catch(err => console.error(`Error loading ${url}:`, err));
 }

--- a/projects.html
+++ b/projects.html
@@ -142,7 +142,7 @@
     </nav>
     <div class="container py-5">
       <h1>Projects</h1>
-      <table id="projects-table"></table>
+      <div id="projects-table"></div>
     </div>
 
     <!-- ======= Start Footer Section ======= -->

--- a/research.html
+++ b/research.html
@@ -142,7 +142,7 @@
     </nav>
     <div class="container py-5">
       <h1>Research Papers</h1>
-      <table id="research-table"></table>
+      <div id="research-table"></div>
     </div>
 
     <!-- ======= Start Footer Section ======= -->


### PR DESCRIPTION
## Summary
- replace `<table>` placeholders with `<div>` containers in projects and research pages
- update `loadSheet` to insert spreadsheet HTML into generic containers instead of tables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c80db2b150832a86fac0e9061667ee