### PR TITLE
Render sheets with div containers

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1480,3 +1480,19 @@ OUR RECRUITER
   overflow-y: auto;
   width: 100%;
 }
+
+.sheet {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.sheet-row {
+  display: flex;
+}
+
+.sheet-cell {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid #dee2e6;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -5,14 +5,23 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 function loadSheet(elementId, url) {
-  const table = document.getElementById(elementId);
-  if (!table) return;
+  const container = document.getElementById(elementId);
+  if (!container) return;
   fetch(url)
     .then(res => res.arrayBuffer())
     .then(data => {
       const wb = XLSX.read(data, { type: 'array' });
       const sheet = wb.SheetNames[0];
-      table.innerHTML = XLSX.utils.sheet_to_html(wb.Sheets[sheet]);
+      const json = XLSX.utils.sheet_to_json(wb.Sheets[sheet], { header: 1 });
+      const maxCols = Math.max(0, ...json.map(row => row.length));
+      const html = json
+        .map(row =>
+          `<div class="sheet-row">${Array.from({ length: maxCols }, (_, i) =>
+            `<div class="sheet-cell">${row[i] !== undefined ? row[i] : ''}</div>`
+          ).join('')}</div>`
+        )
+        .join('');
+      container.innerHTML = `<div class="sheet">${html}</div>`;
     })
     .catch(err => console.error(`Error loading ${url}:`, err));
 }


### PR DESCRIPTION
## Summary
- Replace `sheet_to_html` table rendering with custom div-based layout in `loadSheet`
- Add CSS classes for flexbox rendering of sheet rows and cells

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/drjss/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c80f6e2860832aac39f149e0142003