### PR TITLE
Add profile image and intro text to about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -106,6 +106,18 @@
 
     <!-- ======= Start About Content ======= -->
     <div class="container py-5">
+      <img
+        src="assets/images/mypicture.jpg"
+        alt="Dr. N Junior Sundresh"
+        class="img-fluid mx-auto d-block mb-3"
+        style="max-width:300px;"
+      />
+      <p class="text-center fw-bold">
+        Dr. N Junior Sundresh M.S., F.R.C.S., F.A.C.S., PhD.,<br />
+        Professor of General Surgery<br />
+        Medical Superintendent<br />
+        Senate Member, Tamil Nadu Dr. M.G.R. Medical University
+      </p>
       <h1>About Me</h1>
       <p>
         I am Dr. N. Junior Sundresh, Professor of Surgery and Medical Superintendent at the Government Medical College and Hospital, Cuddalore District. With more than two decades of academic, clinical, and administrative experience, my journey in medicine has been shaped by a passion for patient care, surgical excellence, medical education, and healthcare leadership.


### PR DESCRIPTION
## Summary
- add a responsive portrait image to the top of the About section
- highlight professional titles beneath the image for quick context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c834fb9c94832a836f41e1ab2cf3b2